### PR TITLE
install af dev pakker

### DIFF
--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -35,6 +35,10 @@ jobs:
         run: |
           python3 -m pip install --upgrade pip setuptools wheel pyyaml==5.3.1 requests
 
+      - name: Install libs
+        run: |
+          sudo apt-get install libgdal-dev libgeos-dev libproj-dev
+
       - name: Checkout the lesson
         uses: actions/checkout@v3
         with:


### PR DESCRIPTION
Problemet med at køre raster funktionerne lader til at være forbundet med manglende installation af nogle dev-pakker i R.
Så nu ser vi om jeg kan finde ud af at installere libgda libgeos og libproj i github workflowet.