### PR TITLE
fejlretning

### DIFF
--- a/bin/dependencies.R
+++ b/bin/dependencies.R
@@ -64,9 +64,9 @@ identify_dependencies <- function() {
 
   required_pkgs <- unique(c(
     ## Packages for episodes
-    renv::dependencies(eps, progress = FALSE, error = "ignored")$Package,
+    renv::dependencies(eps, progress = FALSE, errors = "ignored")$Package,
     ## Packages for tools
-    renv::dependencies(bin, progress = FALSE, error = "ignored")$Package
+    renv::dependencies(bin, progress = FALSE, errors = "ignored")$Package
   ))
 
   required_pkgs


### PR DESCRIPTION
Build af siden fejler. Og det gør den på mange andre sider.
i dependencies.R er der et kald til funktionen renv::dependencies. Det har haft argumentet error = "ignored". funktionen er blevet opdateret og skal nu have errors = "ignored". 

Vi ser om ikke det løser problemet.